### PR TITLE
Specify union() from dplyr (not lubridate)

### DIFF
--- a/covid.Rmd
+++ b/covid.Rmd
@@ -116,7 +116,7 @@ coalesce_join <- function(x, y,
                           join = dplyr::full_join, ...) {
     joined <- join(x, y, by = by, suffix = suffix, ...)
     # names of desired output
-    cols <- union(names(x), names(y))
+    cols <- dplyr::union(names(x), names(y))
     
     to_coalesce <- names(joined)[!names(joined) %in% cols]
     suffix_used <- suffix[ifelse(endsWith(to_coalesce, suffix[1]), 1, 2)]


### PR DESCRIPTION
Closes #1

It's regrettable that both dplyr and lubridate export `union()`, but ah well. This is nice for those who use conflicted.